### PR TITLE
fixed the issue to accept 0 and null and changed the default text value to remaining downloads

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -73,13 +73,12 @@ class ApiController extends OCSController {
 	 *
 	 * Set the download limit for a given link share
 	 */
-	public function setDownloadLimit(string $token, $limit): Response {
+	public function setDownloadLimit(string $token, int $limit): Response {
 		$this->validateToken($token);
-		$limit = trim($limit);
 
 		// Count needs to be at least 0 or null
-		if (!is_numeric($limit) && $limit !== '') {
-			throw new OCSBadRequestException('Limit must be greater than or equal to 0 or null');
+		if ($limit < 0) {
+			throw new OCSBadRequestException('Limit must be greater than or equal to 0');
 		}
 
 		// Getting existing limit and init if unset
@@ -94,17 +93,13 @@ class ApiController extends OCSController {
 
 		// Update DB
 		$shareLimit->setLimit($limit);
-		if($limit == 0 || $limit == ''){
+		if($limit === 0){
 			$this->mapper->delete($shareLimit);
 		} else {
-			if($limit < 0) {
-				throw new OCSBadRequestException('Limit must be greater than or equal to 0 or null');
+			if ($insert) {
+				$this->mapper->insert($shareLimit);
 			} else {
-				if ($insert) {
-					$this->mapper->insert($shareLimit);
-				} else {
-					$this->mapper->update($shareLimit);
-				}
+				$this->mapper->update($shareLimit);
 			}
 		}
 

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -95,12 +95,10 @@ class ApiController extends OCSController {
 		$shareLimit->setLimit($limit);
 		if($limit === 0){
 			$this->mapper->delete($shareLimit);
+		} elseif ($insert) {
+			$this->mapper->insert($shareLimit);
 		} else {
-			if ($insert) {
-				$this->mapper->insert($shareLimit);
-			} else {
-				$this->mapper->update($shareLimit);
-			}
+			$this->mapper->update($shareLimit);
 		}
 
 		return new DataResponse();

--- a/src/models/DownloadLimitAction.js
+++ b/src/models/DownloadLimitAction.js
@@ -48,7 +48,7 @@ export default class DownloadLimitAction {
 			icon: 'icon-download',
 			is: this._store.enabled ? ActionInput : null,
 			text: t('files_downloadlimit', 'Download limit'),
-			title: t('files_downloadlimit', 'Download count: {count}', this._store),
+			title: t('files_downloadlimit', 'Downloads: {count}', this._store),
 			value: this._store.limit ? this._store.limit - this._store.count : this._store.limit,
 		}
 	}

--- a/src/models/DownloadLimitAction.js
+++ b/src/models/DownloadLimitAction.js
@@ -49,7 +49,7 @@ export default class DownloadLimitAction {
 			is: this._store.enabled ? ActionInput : null,
 			text: t('files_downloadlimit', 'Download limit'),
 			title: t('files_downloadlimit', 'Download count: {count}', this._store),
-			value: this._store.limit,
+			value: this._store.limit ? this._store.limit - this._store.count : this._store.limit,
 		}
 	}
 


### PR DESCRIPTION
1. Fixed the issue to accept 0 and null
Use case for null value - If I remove existing value from the text box, the download limit should get removed for that particular share.
Use case for 0 value - If I put 0 or change the existing value to 0, then the download limit should get removed for that particular share.
2. Changed the default text value from total download count to remaining download count
3. Changed the hover text from Download limit: to Downloads: