### PR TITLE
Fix public handling of limited shares

### DIFF
--- a/css/public.css
+++ b/css/public.css
@@ -1,0 +1,3 @@
+#imgframe {
+	pointer-events: none;
+}

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -91,8 +91,11 @@ class ApiController extends OCSController {
 			$insert = true;
 		}
 
-		// Update DB
+		// Set new limit
 		$shareLimit->setLimit($limit);
+		// Reset existing counter
+		$shareLimit->setDownloads(0);
+		// Update DB
 		if ($insert) {
 			$this->mapper->insert($shareLimit);
 		} else {


### PR DESCRIPTION
- [ ] Reset the counter when setting a new limit
- [ ] Display a message and hide the button when limit is reached and share disabled
- [ ] Display a warning when clicking the download button more than once

Fix https://github.com/nextcloud/files_downloadlimit/issues/43

