### PR TITLE
Prevent sending null or empty download limits

### DIFF
--- a/src/models/DownloadLimitAction.js
+++ b/src/models/DownloadLimitAction.js
@@ -24,7 +24,7 @@ import { translate as t } from '@nextcloud/l10n'
 import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
 import debounce from 'debounce'
 
-import { setDownloadLimit } from '../service/DownloadLimitService'
+import { setDownloadLimit, deleteDownloadLimit } from '../service/DownloadLimitService'
 
 export default class DownloadLimitAction {
 
@@ -57,8 +57,17 @@ export default class DownloadLimitAction {
 	get handlers() {
 		return {
 			'update:value': debounce(async (limit) => {
+				console.debug('[DEBUG]', appName, 'Setting limit of ' + this._store.token + ' to ' + limit)
 				this._store.loading = true
-				await setDownloadLimit(this._store.token, limit)
+
+				// If the value is not correct, let's remove the limit
+				if (!parseInt(limit) || parseInt(limit) < 1) {
+					await deleteDownloadLimit(this._store.token)
+				} else {
+					await setDownloadLimit(this._store.token, limit)
+				}
+
+				// Done loading
 				this._store.loading = false
 			}, 300),
 		}


### PR DESCRIPTION
Accepting 0 and null in the API is not correct, the values are still invalid.
We need to process them properly as they are in the front imo.

closes #69 