### PR TITLE
chore: Disable ocp update for stable branches

### DIFF
--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'master', 'stable28', 'stable27', 'stable26']
+        branches: ['main', 'master']
 
     name: update-nextcloud-ocp-${{ matrix.branches }}
 


### PR DESCRIPTION
- Close https://github.com/nextcloud/files_downloadlimit/issues/247

stable28 does not use nextcloud/ocp