### PR TITLE
[master] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3989,10 +3989,11 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
-      "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
+      "version": "6.5.6",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
+      "integrity": "sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",


### PR DESCRIPTION
# Audit report

This audit fix resolves 7 of the total 11 vulnerabilities found in your project.

## Updated dependencies
* [browserify-sign](#user-content-browserify-sign)
* [create-ecdh](#user-content-create-ecdh)
* [crypto-browserify](#user-content-crypto-browserify)
* [elliptic](#user-content-elliptic)
* [node-stdlib-browser](#user-content-node-stdlib-browser)
* [vite-plugin-node-polyfills](#user-content-vite-plugin-node-polyfills)
* [vue-tsc](#user-content-vue-tsc)
## Fixed vulnerabilities

### browserify-sign <a href="#user-content-browserify-sign" id="browserify-sign">#</a>
* Caused by vulnerable dependency:
  * [elliptic](#user-content-elliptic)
* Affected versions: >=4.0.0
* Package usage:
  * `node_modules/browserify-sign`

### create-ecdh <a href="#user-content-create-ecdh" id="create-ecdh">#</a>
* Caused by vulnerable dependency:
  * [elliptic](#user-content-elliptic)
* Affected versions: >=4.0.0
* Package usage:
  * `node_modules/create-ecdh`

### crypto-browserify <a href="#user-content-crypto-browserify" id="crypto-browserify">#</a>
* Caused by vulnerable dependency:
  * [browserify-sign](#user-content-browserify-sign)
  * [create-ecdh](#user-content-create-ecdh)
* Affected versions: >=3.11.0
* Package usage:
  * `node_modules/crypto-browserify`

### elliptic <a href="#user-content-elliptic" id="elliptic">#</a>
* Elliptic allows BER-encoded signatures
* Severity: **low** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-49q7-c7j4-3p7m](https://github.com/advisories/GHSA-49q7-c7j4-3p7m)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/elliptic`

### node-stdlib-browser <a href="#user-content-node-stdlib-browser" id="node-stdlib-browser">#</a>
* Caused by vulnerable dependency:
  * [crypto-browserify](#user-content-crypto-browserify)
* Affected versions: *
* Package usage:
  * `node_modules/node-stdlib-browser`

### vite-plugin-node-polyfills <a href="#user-content-vite-plugin-node-polyfills" id="vite-plugin-node-polyfills">#</a>
* Caused by vulnerable dependency:
  * [node-stdlib-browser](#user-content-node-stdlib-browser)
* Affected versions: >=0.3.0
* Package usage:
  * `node_modules/vite-plugin-node-polyfills`

### vue-tsc <a href="#user-content-vue-tsc" id="vue-tsc">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
* Affected versions: 1.7.0-alpha.0 - 2.0.28
* Package usage:
  * `node_modules/vue-tsc`